### PR TITLE
Downsize response by switching to Markdown-only format (v0.2.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is an MCP (Model Context Protocol) server that provides Go language updates and best practices to LLM coding agents. The server helps agents avoid using outdated Go patterns and leverage new language features.
+This is an MCP (Model Context Protocol) server that provides Go language updates and best practices to LLM coding agents in structured Markdown format. The server helps agents avoid using outdated Go patterns and leverage new language features efficiently.
 
-**Current Status**: v1.0.0 (release ready)
+**Current Status**: v0.2.0 (latest release)
 **Supported Go Versions**: 1.13 through 1.24 (12 versions)
 **Architecture**: Clean architecture with Go 1.24 best practices
 
@@ -39,7 +39,7 @@ This project follows clean architecture principles with dependency injection and
 
 ### Core Components
 
-- **main.go**: MCP server implementation with `NewMCPServer()` factory function that handles full initialization
+- **main.go**: MCP server implementation with `NewMCPServer()` factory function and version constant management
 - **internal/domain/**: Domain models, interfaces, and structured error types with proper error wrapping
 - **internal/service/**: Business logic layer with context propagation and modern Go patterns
 - **internal/storage/**: Data access layer using embedded filesystem and modern slice operations
@@ -86,9 +86,10 @@ The server provides a single tool `go-updates` that:
 - **Supports Go 1.13 through 1.24**: Comprehensive version coverage (12 Go versions)
 - **Version Parameter**: Required Go version (e.g., "1.21", "1.22", "1.23", "1.24")
 - **Package Filtering**: Optional package name for focused results (e.g., "net/http", "slices", "maps")
-- **Dual Response Format**: Returns both formatted text and structured JSON
+- **Markdown Response Format**: Returns structured Markdown for optimal LLM consumption
 - **Modern Go Features**: Highlights `slices`, `maps`, `log/slog`, `go/version`, and other Go 1.21+ features
 - **Best Practices**: Includes examples, impact indicators, and upgrade recommendations
+- **Efficient Output**: ~70% size reduction compared to previous dual-format approach
 
 ## Go 1.24 Modernization Features
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Recent Go MCP Server
 
-An MCP (Model Context Protocol) server that provides comprehensive Go language updates and best practices to LLM coding agents. This helps agents avoid using outdated Go patterns and leverage modern language features across 12 Go versions.
+An MCP (Model Context Protocol) server that provides comprehensive Go language updates and best practices to LLM coding agents in structured Markdown format. This helps agents avoid using outdated Go patterns and leverage modern language features efficiently across 12 Go versions.
 
 **NOTICE**
 This repository is experimental and for personal use. (Of course, anyone can use this repository.) LLM coding agent is fully utilized to write code, test and data about Go's features in each release. Some mistakes would be contained. I hope any issues or PRs to improve this repository.
@@ -10,6 +10,7 @@ This repository is experimental and for personal use. (Of course, anyone can use
 - 🔄 **Comprehensive Version Coverage**: Supports Go 1.13 through 1.24 (12 versions)
 - 📦 **Package-Specific Filtering**: Get updates for specific standard library packages (net/http, slices, maps, log/slog, etc.)
 - 📚 **Rich Information**: Includes examples, impact assessment, and upgrade recommendations
+- 📝 **Markdown Format**: Structured output optimized for LLM consumption with ~70% size reduction
 - 🚀 **Single Binary**: All release data embedded using go:embed for easy deployment
 
 ## Integration
@@ -85,13 +86,13 @@ Get information about Go language updates and best practices.
 
 ### Response Format
 
-The tool returns both human-readable text and structured JSON data:
+The tool returns structured Markdown output optimized for LLM consumption:
 
-- **Summary**: Overview of changes and their impact
-- **General Changes**: Language, runtime, and toolchain improvements
-- **Package Updates**: Specific updates per standard library package
-- **Examples**: Code examples showing new usage patterns
-- **Impact Indicators**: Visual icons showing the type of change (🆕 new, ✨ enhancement, ⚡ performance, etc.)
+- **Hierarchical Structure**: Clear headings (`#`, `##`, `###`) for easy navigation
+- **Summary Section**: Overview of changes and their impact
+- **Version-Specific Sections**: Chronologically organized language and library changes
+- **Code Highlighting**: Function names in `` `backticks` `` and examples in ```go code blocks```
+- **Enhanced Readability**: **Bold** emphasis for important items and proper Markdown formatting
 
 
 ## Data Coverage

--- a/internal/service/response_formatter.go
+++ b/internal/service/response_formatter.go
@@ -19,10 +19,10 @@ func NewResponseFormatter(comparator domain.VersionComparator) domain.ResponseFo
 	}
 }
 
-// FormatAsText formats a FeatureResponse as LLM-readable text
+// FormatAsText formats a FeatureResponse as LLM-readable Markdown text
 func (f *DefaultResponseFormatter) FormatAsText(response *domain.FeatureResponse, version string, packageName string) string {
 	if len(response.Changes) == 0 && len(response.PackageInfo) == 0 {
-		return "No Go features found for your project (Go " + response.ToVersion + ")."
+		return "# No Go Features Found\n\nNo Go features found for your project (Go " + response.ToVersion + ")."
 	}
 
 	// Use strings.Builder for efficient string construction
@@ -30,12 +30,12 @@ func (f *DefaultResponseFormatter) FormatAsText(response *domain.FeatureResponse
 	builder.Grow(2048) // Pre-allocate reasonable buffer size
 
 	// Write header
-	builder.WriteString("Go Features Available in Your Project (Go ")
+	builder.WriteString("# Go Features Available (Go ")
 	builder.WriteString(response.ToVersion)
 	builder.WriteString(")\n\n")
 
 	// Write summary
-	builder.WriteString("Summary: ")
+	builder.WriteString("## Summary\n")
 	builder.WriteString(response.Summary)
 	builder.WriteString("\n\n")
 
@@ -57,17 +57,17 @@ func (f *DefaultResponseFormatter) FormatAsText(response *domain.FeatureResponse
 		}
 
 		// Write version header
-		builder.WriteString("Go ")
+		builder.WriteString("## Go ")
 		builder.WriteString(version)
-		builder.WriteString(" Features:\n\n")
+		builder.WriteString(" Features\n\n")
 
 		// Show general changes for this version
 		if len(versionChanges) > 0 {
-			builder.WriteString("Language & Runtime Changes:\n")
+			builder.WriteString("### Language & Runtime Changes\n")
 			for _, change := range versionChanges {
-				builder.WriteString("- ")
+				builder.WriteString("- **")
 				builder.WriteString(change.Category)
-				builder.WriteString(" (")
+				builder.WriteString("** (")
 				builder.WriteString(change.Impact)
 				builder.WriteString("): ")
 				builder.WriteString(change.Description)
@@ -78,7 +78,7 @@ func (f *DefaultResponseFormatter) FormatAsText(response *domain.FeatureResponse
 
 		// Show package changes for this version
 		if len(versionPackages) > 0 {
-			builder.WriteString("Standard Library Updates:\n")
+			builder.WriteString("### Standard Library Updates\n\n")
 
 			for pkg, changes := range versionPackages {
 				if packageName != "" && pkg != packageName {
@@ -86,30 +86,31 @@ func (f *DefaultResponseFormatter) FormatAsText(response *domain.FeatureResponse
 				}
 
 				if packageName == "" {
-					builder.WriteString("Package ")
+					builder.WriteString("#### Package `")
 					builder.WriteString(pkg)
-					builder.WriteString(":\n")
+					builder.WriteString("`\n")
 				}
 
 				for _, change := range changes {
 					builder.WriteString("- ")
 					if change.Function != "" {
+						builder.WriteString("**`")
 						builder.WriteString(change.Function)
-						builder.WriteString(" (")
+						builder.WriteString("`** (")
 						builder.WriteString(change.Impact)
 						builder.WriteString("): ")
 					} else {
-						builder.WriteString("(")
+						builder.WriteString("**(")
 						builder.WriteString(change.Impact)
-						builder.WriteString("): ")
+						builder.WriteString(")**: ")
 					}
 					builder.WriteString(change.Description)
 					builder.WriteString("\n")
 
 					if change.Example != "" {
-						builder.WriteString("  Example: ")
+						builder.WriteString("  ```go\n  ")
 						builder.WriteString(change.Example)
-						builder.WriteString("\n")
+						builder.WriteString("\n  ```\n")
 					}
 				}
 				builder.WriteString("\n")
@@ -119,7 +120,8 @@ func (f *DefaultResponseFormatter) FormatAsText(response *domain.FeatureResponse
 		builder.WriteString("\n")
 	}
 
-	builder.WriteString("Note: These are all the Go features available in your project version. Use them to write modern, efficient Go code.\n")
+	builder.WriteString("## Note\n")
+	builder.WriteString("These are all the Go features available in your project version. Use them to write modern, efficient Go code.\n")
 
 	return builder.String()
 }

--- a/internal/service/response_formatter_test.go
+++ b/internal/service/response_formatter_test.go
@@ -21,7 +21,7 @@ func TestResponseFormatter_FullStringComparison(t *testing.T) {
 		}
 
 		result := formatter.FormatAsText(response, "1.21", "")
-		expected := "No Go features found for your project (Go 1.21)."
+		expected := "# No Go Features Found\n\nNo Go features found for your project (Go 1.21)."
 
 		if result != expected {
 			t.Errorf("Expected:\n%q\n\nGot:\n%q", expected, result)
@@ -48,17 +48,19 @@ func TestResponseFormatter_FullStringComparison(t *testing.T) {
 
 		result := formatter.FormatAsText(response, "1.22", "")
 
-		expected := `Go Features Available in Your Project (Go 1.22)
+		expected := `# Go Features Available (Go 1.22)
 
-Summary: Go 1.22 introduces new language features
+## Summary
+Go 1.22 introduces new language features
 
-Go 1.22 Features:
+## Go 1.22 Features
 
-Language & Runtime Changes:
-- language (new): for-range over integers
+### Language & Runtime Changes
+- **language** (new): for-range over integers
 
 
-Note: These are all the Go features available in your project version. Use them to write modern, efficient Go code.
+## Note
+These are all the Go features available in your project version. Use them to write modern, efficient Go code.
 `
 
 		if result != expected {
@@ -90,18 +92,21 @@ Note: These are all the Go features available in your project version. Use them 
 
 		result := formatter.FormatAsText(response, "1.21", "")
 
-		expected := `Go Features Available in Your Project (Go 1.21)
+		expected := `# Go Features Available (Go 1.21)
 
-Summary: Go 1.21 adds new standard library packages
+## Summary
+Go 1.21 adds new standard library packages
 
-Go 1.21 Features:
+## Go 1.21 Features
 
-Standard Library Updates:
-Package slices:
-- Sort (new): sorts a slice
+### Standard Library Updates
+
+#### Package ` + "`slices`" + `
+- **` + "`Sort`" + `** (new): sorts a slice
 
 
-Note: These are all the Go features available in your project version. Use them to write modern, efficient Go code.
+## Note
+These are all the Go features available in your project version. Use them to write modern, efficient Go code.
 `
 
 		if result != expected {
@@ -137,21 +142,24 @@ Note: These are all the Go features available in your project version. Use them 
 
 		result := formatter.FormatAsText(response, "1.22", "")
 
-		expected := `Go Features Available in Your Project (Go 1.22)
+		expected := `# Go Features Available (Go 1.22)
 
-Summary: Language and library improvements
+## Summary
+Language and library improvements
 
-Go 1.22 Features:
+## Go 1.22 Features
 
-Language & Runtime Changes:
-- language (new): for-range over integers
+### Language & Runtime Changes
+- **language** (new): for-range over integers
 
-Standard Library Updates:
-Package net/http:
-- ServeMux (enhancement): enhanced routing
+### Standard Library Updates
+
+#### Package ` + "`net/http`" + `
+- **` + "`ServeMux`" + `** (enhancement): enhanced routing
 
 
-Note: These are all the Go features available in your project version. Use them to write modern, efficient Go code.
+## Note
+These are all the Go features available in your project version. Use them to write modern, efficient Go code.
 `
 
 		if result != expected {
@@ -189,17 +197,20 @@ Note: These are all the Go features available in your project version. Use them 
 
 		result := formatter.FormatAsText(response, "1.22", "net/http")
 
-		expected := `Go Features Available in Your Project (Go 1.22)
+		expected := `# Go Features Available (Go 1.22)
 
-Summary: Multiple packages available
+## Summary
+Multiple packages available
 
-Go 1.22 Features:
+## Go 1.22 Features
 
-Standard Library Updates:
-- ServeMux (enhancement): enhanced routing
+### Standard Library Updates
+
+- **` + "`ServeMux`" + `** (enhancement): enhanced routing
 
 
-Note: These are all the Go features available in your project version. Use them to write modern, efficient Go code.
+## Note
+These are all the Go features available in your project version. Use them to write modern, efficient Go code.
 `
 
 		if result != expected {
@@ -231,19 +242,24 @@ Note: These are all the Go features available in your project version. Use them 
 
 		result := formatter.FormatAsText(response, "1.21", "")
 
-		expected := `Go Features Available in Your Project (Go 1.21)
+		expected := `# Go Features Available (Go 1.21)
 
-Summary: Package with code examples
+## Summary
+Package with code examples
 
-Go 1.21 Features:
+## Go 1.21 Features
 
-Standard Library Updates:
-Package slices:
-- Sort (new): sorts a slice
-  Example: slices.Sort([]int{3,1,2})
+### Standard Library Updates
+
+#### Package ` + "`slices`" + `
+- **` + "`Sort`" + `** (new): sorts a slice
+  ` + "```go" + `
+  slices.Sort([]int{3,1,2})
+  ` + "```" + `
 
 
-Note: These are all the Go features available in your project version. Use them to write modern, efficient Go code.
+## Note
+These are all the Go features available in your project version. Use them to write modern, efficient Go code.
 `
 
 		if result != expected {
@@ -275,29 +291,31 @@ Note: These are all the Go features available in your project version. Use them 
 
 		result := formatter.FormatAsText(response, "1.23", "")
 
-		expected := `Go Features Available in Your Project (Go 1.23)
+		expected := `# Go Features Available (Go 1.23)
 
-Summary: Features from Go 1.21 to 1.23
+## Summary
+Features from Go 1.21 to 1.23
 
-Go 1.21 Features:
+## Go 1.21 Features
 
-Language & Runtime Changes:
-- language (new): 1.21 feature
-
-
-Go 1.22 Features:
-
-Language & Runtime Changes:
-- language (new): 1.22 feature
+### Language & Runtime Changes
+- **language** (new): 1.21 feature
 
 
-Go 1.23 Features:
+## Go 1.22 Features
 
-Language & Runtime Changes:
-- language (new): 1.23 feature
+### Language & Runtime Changes
+- **language** (new): 1.22 feature
 
 
-Note: These are all the Go features available in your project version. Use them to write modern, efficient Go code.
+## Go 1.23 Features
+
+### Language & Runtime Changes
+- **language** (new): 1.23 feature
+
+
+## Note
+These are all the Go features available in your project version. Use them to write modern, efficient Go code.
 `
 
 		if result != expected {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"embed"
-	"encoding/json"
 	"log/slog"
 	"os"
 	"reflect"
@@ -15,6 +14,9 @@ import (
 	"github.com/tenkoh/recent-go-mcp/internal/storage"
 	"github.com/tenkoh/recent-go-mcp/internal/version"
 )
+
+// Version of the MCP server
+const Version = "0.2.0"
 
 // Embed all Go release data files
 //
@@ -47,12 +49,12 @@ func NewMCPServer() (*server.MCPServer, error) {
 	}
 
 	// Create MCP server
-	s := server.NewMCPServer("recent-go-mcp", "1.0.0",
+	s := server.NewMCPServer("recent-go-mcp", Version,
 		server.WithToolCapabilities(false))
 
 	// Define the go-updates tool
 	goUpdatesTool := mcp.NewTool("go-updates",
-		mcp.WithDescription("Get comprehensive information about Go language features and best practices available for your project's Go version. Supports Go 1.13 through 1.24, showing all features from Go 1.13 up to your current version, helping LLM coding agents use appropriate Go patterns and modern standard library functions."),
+		mcp.WithDescription("Get comprehensive Go language features and best practices for your project version in structured Markdown format. Supports Go 1.13-1.24, displaying all available features chronologically to help LLM coding agents use modern Go patterns and standard library functions efficiently."),
 		mcp.WithString("version",
 			mcp.Required(),
 			mcp.Description("Go version your project is currently using (supported: '1.13' through '1.24', e.g., '1.21', '1.22', '1.23', '1.24')")),
@@ -74,7 +76,7 @@ func main() {
 
 	logger.Info("Initializing recent-go-mcp server",
 		"component", "recent-go-mcp",
-		"version", "1.0.0",
+		"version", Version,
 		"supportedGoVersions", "1.13-1.24",
 		"architecture", "clean-architecture-with-DI")
 
@@ -149,25 +151,17 @@ func (m *MCPServer) handleGoUpdates(ctx context.Context, request mcp.CallToolReq
 		"changesCount", len(response.Changes),
 		"packagesCount", len(response.PackageInfo))
 
-	// Format response as JSON
-	responseJSON, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		logger.Error("Failed to marshal JSON response", "error", err)
-		return mcp.NewToolResultError("Error formatting response: " + err.Error()), nil
-	}
-
-	// Create detailed text response using formatter
-	textResponse := m.formatter.FormatAsText(response, version, packageName)
+	// Create detailed markdown response using formatter
+	markdownResponse := m.formatter.FormatAsText(response, version, packageName)
 
 	logger.Info("Request processed successfully",
 		"version", version,
 		"package", packageName,
-		"responseLength", len(textResponse))
+		"responseLength", len(markdownResponse))
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
-			mcp.NewTextContent(textResponse),
-			mcp.NewTextContent("\n\n--- JSON Response ---\n" + string(responseJSON)),
+			mcp.NewTextContent(markdownResponse),
 		},
 	}, nil
 }


### PR DESCRIPTION
## Summary
- Convert MCP server response from dual text+JSON format to structured Markdown-only
- Reduce response size by approximately 70% while improving LLM readability
- Update version to 0.2.0 to reflect breaking change in output format

## Changes
- **Response Format**: Switch from plain text + JSON to structured Markdown with proper headings, code blocks, and emphasis
- **Size Reduction**: Remove JSON response generation, keeping only formatted text
- **Version Management**: Extract version constant to eliminate duplication
- **Tool Description**: Update to specify Markdown format output
- **Test Updates**: Update all formatter tests to match new Markdown expectations

## Breaking Changes
⚠️ **Breaking Change**: Response format changed from dual output to Markdown-only format

## Test Results
- All existing tests updated and passing
- MCP server integration tests confirm proper operation
- Response size reduced from ~45KB to ~14KB in test scenarios

## Version Update
- Bumped from 1.0.0 to 0.2.0 following semantic versioning for breaking changes