### PR TITLE
Add Go 1.25 release data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This is an MCP (Model Context Protocol) server that provides Go language updates and best practices to LLM coding agents in structured Markdown format. The server helps agents avoid using outdated Go patterns and leverage new language features efficiently.
 
 **Current Status**: v0.2.0 (latest release)
-**Supported Go Versions**: 1.13 through 1.24 (12 versions)
-**Architecture**: Clean architecture with Go 1.24 best practices
+**Supported Go Versions**: 1.13 through 1.25 (13 versions)
+**Architecture**: Clean architecture with Go 1.25 best practices
 
 ## Common Commands
 
@@ -29,13 +29,13 @@ go test -v -run TestMCPServer
 
 # Manual JSON-RPC testing (if needed)
 echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' | ./recent-go-mcp
-echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "go-updates", "arguments": {"version": "1.24"}}}' | ./recent-go-mcp
+echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "go-updates", "arguments": {"version": "1.25"}}}' | ./recent-go-mcp
 echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "go-updates", "arguments": {"version": "1.22", "package": "slices"}}}' | ./recent-go-mcp
 ```
 
 ## Architecture
 
-This project follows clean architecture principles with dependency injection and Go 1.24 best practices for improved testability and maintainability.
+This project follows clean architecture principles with dependency injection and Go 1.25 best practices for improved testability and maintainability.
 
 ### Core Components
 
@@ -44,7 +44,7 @@ This project follows clean architecture principles with dependency injection and
 - **internal/service/**: Business logic layer with context propagation and modern Go patterns
 - **internal/storage/**: Data access layer using embedded filesystem and modern slice operations
 - **internal/version/**: Version comparison using Go 1.22+ `go/version` package (simplified from manual parsing)
-- **data/releases/**: Individual JSON files for Go 1.13-1.24 (embedded via go:embed)
+- **data/releases/**: Individual JSON files for Go 1.13-1.25 (embedded via go:embed)
 
 ### Key Design Patterns
 
@@ -54,7 +54,7 @@ This project follows clean architecture principles with dependency injection and
 - **Embedded Data**: Uses `//go:embed` in main.go to include JSON data in the binary
 - **MCP Protocol**: Implements Model Context Protocol for LLM integration
 - **SOLID Principles**: Single responsibility, dependency inversion, and open/closed principles
-- **Go 1.24 Best Practices**: Modern error handling, context propagation, structured logging, and efficient operations
+- **Go 1.25 Best Practices**: Modern error handling, context propagation, structured logging, and efficient operations
 
 ### Adding New Go Versions
 
@@ -83,17 +83,17 @@ This project follows clean architecture principles with dependency injection and
 ### MCP Integration
 
 The server provides a single tool `go-updates` that:
-- **Supports Go 1.13 through 1.24**: Comprehensive version coverage (12 Go versions)
-- **Version Parameter**: Required Go version (e.g., "1.21", "1.22", "1.23", "1.24")
+- **Supports Go 1.13 through 1.25**: Comprehensive version coverage (13 Go versions)
+- **Version Parameter**: Required Go version (e.g., "1.21", "1.22", "1.23", "1.25")
 - **Package Filtering**: Optional package name for focused results (e.g., "net/http", "slices", "maps")
 - **Markdown Response Format**: Returns structured Markdown for optimal LLM consumption
 - **Modern Go Features**: Highlights `slices`, `maps`, `log/slog`, `go/version`, and other Go 1.21+ features
 - **Best Practices**: Includes examples, impact indicators, and upgrade recommendations
 - **Efficient Output**: ~70% size reduction compared to previous dual-format approach
 
-## Go 1.24 Modernization Features
+## Go 1.25 Modernization Features
 
-This codebase demonstrates Go 1.24 best practices:
+This codebase demonstrates Go 1.25 best practices:
 
 - **Structured Error Handling**: Custom error types with proper wrapping and context
 - **Context Propagation**: `context.Context` throughout the service layer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This is an MCP (Model Context Protocol) server that provides Go language updates and best practices to LLM coding agents in structured Markdown format. The server helps agents avoid using outdated Go patterns and leverage new language features efficiently.
 
 **Current Status**: v0.2.0 (latest release)
-**Supported Go Versions**: 1.13 through 1.24 (12 versions)
-**Architecture**: Clean architecture with Go 1.24 best practices
+**Supported Go Versions**: 1.13 through 1.25 (13 versions)
+**Architecture**: Clean architecture with Go 1.25 best practices
 
 ## Common Commands
 
@@ -29,13 +29,13 @@ go test -v -run TestMCPServer
 
 # Manual JSON-RPC testing (if needed)
 echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' | ./recent-go-mcp
-echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "go-updates", "arguments": {"version": "1.24"}}}' | ./recent-go-mcp
+echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "go-updates", "arguments": {"version": "1.25"}}}' | ./recent-go-mcp
 echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "go-updates", "arguments": {"version": "1.22", "package": "slices"}}}' | ./recent-go-mcp
 ```
 
 ## Architecture
 
-This project follows clean architecture principles with dependency injection and Go 1.24 best practices for improved testability and maintainability.
+This project follows clean architecture principles with dependency injection and Go 1.25 best practices for improved testability and maintainability.
 
 ### Core Components
 
@@ -44,7 +44,7 @@ This project follows clean architecture principles with dependency injection and
 - **internal/service/**: Business logic layer with context propagation and modern Go patterns
 - **internal/storage/**: Data access layer using embedded filesystem and modern slice operations
 - **internal/version/**: Version comparison using Go 1.22+ `go/version` package (simplified from manual parsing)
-- **data/releases/**: Individual JSON files for Go 1.13-1.24 (embedded via go:embed)
+- **data/releases/**: Individual JSON files for Go 1.13-1.25 (embedded via go:embed)
 
 ### Key Design Patterns
 
@@ -54,7 +54,7 @@ This project follows clean architecture principles with dependency injection and
 - **Embedded Data**: Uses `//go:embed` in main.go to include JSON data in the binary
 - **MCP Protocol**: Implements Model Context Protocol for LLM integration
 - **SOLID Principles**: Single responsibility, dependency inversion, and open/closed principles
-- **Go 1.24 Best Practices**: Modern error handling, context propagation, structured logging, and efficient operations
+- **Go 1.25 Best Practices**: Modern error handling, context propagation, structured logging, and efficient operations
 
 ### Adding New Go Versions
 
@@ -83,17 +83,17 @@ This project follows clean architecture principles with dependency injection and
 ### MCP Integration
 
 The server provides a single tool `go-updates` that:
-- **Supports Go 1.13 through 1.24**: Comprehensive version coverage (12 Go versions)
-- **Version Parameter**: Required Go version (e.g., "1.21", "1.22", "1.23", "1.24")
+- **Supports Go 1.13 through 1.25**: Comprehensive version coverage (13 Go versions)
+- **Version Parameter**: Required Go version (e.g., "1.21", "1.22", "1.23", "1.25")
 - **Package Filtering**: Optional package name for focused results (e.g., "net/http", "slices", "maps")
 - **Markdown Response Format**: Returns structured Markdown for optimal LLM consumption
 - **Modern Go Features**: Highlights `slices`, `maps`, `log/slog`, `go/version`, and other Go 1.21+ features
 - **Best Practices**: Includes examples, impact indicators, and upgrade recommendations
 - **Efficient Output**: ~70% size reduction compared to previous dual-format approach
 
-## Go 1.24 Modernization Features
+## Go 1.25 Modernization Features
 
-This codebase demonstrates Go 1.24 best practices:
+This codebase demonstrates Go 1.25 best practices:
 
 - **Structured Error Handling**: Custom error types with proper wrapping and context
 - **Context Propagation**: `context.Context` throughout the service layer

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Recent Go MCP Server
 
-An MCP (Model Context Protocol) server that provides comprehensive Go language updates and best practices to LLM coding agents in structured Markdown format. This helps agents avoid using outdated Go patterns and leverage modern language features efficiently across 12 Go versions.
+An MCP (Model Context Protocol) server that provides comprehensive Go language updates and best practices to LLM coding agents in structured Markdown format. This helps agents avoid using outdated Go patterns and leverage modern language features efficiently across 13 Go versions.
 
 **NOTICE**
 This repository is experimental and for personal use. (Of course, anyone can use this repository.) LLM coding agent is fully utilized to write code, test and data about Go's features in each release. Some mistakes would be contained. I hope any issues or PRs to improve this repository.
@@ -11,7 +11,7 @@ I will update this tool with pagenation feature soon.
 
 ## Features
 
-- 🔄 **Comprehensive Version Coverage**: Supports Go 1.13 through 1.24 (12 versions)
+- 🔄 **Comprehensive Version Coverage**: Supports Go 1.13 through 1.25 (13 versions)
 - 📦 **Package-Specific Filtering**: Get updates for specific standard library packages (net/http, slices, maps, log/slog, etc.)
 - 📚 **Rich Information**: Includes examples, impact assessment, and upgrade recommendations
 - 📝 **Markdown Format**: Structured output optimized for LLM consumption with ~70% size reduction
@@ -52,12 +52,12 @@ The server implements the Model Context Protocol and can be used with any MCP-co
 Get information about Go language updates and best practices.
 
 **Parameters:**
-- `version` (required): Go version to check updates from (supported: "1.13" through "1.24")
+- `version` (required): Go version to check updates from (supported: "1.13" through "1.25")
 - `package` (optional): Specific standard library package to filter updates (e.g., "net/http", "slices", "maps", "log/slog")
 
 ### Examples
 
-#### Get all updates from Go 1.21 to Go 1.24
+#### Get all updates from Go 1.21 to Go 1.25
 ```json
 {
   "jsonrpc": "2.0",
@@ -102,7 +102,7 @@ The tool returns structured Markdown output optimized for LLM consumption:
 ## Data Coverage
 
 **Comprehensive Go Version Support:**
-- Go 1.13 through Go 1.24 (12 versions)
+- Go 1.13 through Go 1.25 (13 versions)
 - Complete coverage from legacy versions to the latest features
 
 **The embedded data covers:**
@@ -130,7 +130,7 @@ go build -o recent-go-mcp
 
 # Test manually with JSON-RPC
 echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' | ./recent-go-mcp
-echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "go-updates", "arguments": {"version": "1.24"}}}' | ./recent-go-mcp
+echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "go-updates", "arguments": {"version": "1.25"}}}' | ./recent-go-mcp
 ```
 
 ## License

--- a/data/releases/go1.25.json
+++ b/data/releases/go1.25.json
@@ -134,386 +134,454 @@
       {
         "function": "Wait",
         "description": "Blocks until all goroutines in the bubble are waiting, ensuring the test reaches quiescence before assertions.",
-        "impact": "new"
+        "impact": "new",
+        "example": "synctest.Test(func(t *synctest.T) {\n    go doWork(t.Context())\n    synctest.Wait(t)\n})"
       }
     ],
     "encoding/json/v2": [
       {
         "description": "Experimental JSON implementation activated with GOEXPERIMENT=jsonv2, delivering faster decoding and new configuration options.",
-        "impact": "new"
+        "impact": "new",
+        "example": "GOEXPERIMENT=jsonv2 go test ./..."
       },
       {
         "package": "encoding/json/jsontext",
         "description": "Companion low-level package exposes JSON tokenization APIs when the experiment is enabled.",
-        "impact": "new"
+        "impact": "new",
+        "example": "decoder := jsontext.NewDecoder(strings.NewReader(data))"
       }
     ],
     "encoding/json": [
       {
         "description": "Uses the v2 implementation when GOEXPERIMENT=jsonv2 is set, maintaining marshal semantics but changing error text and adding new options.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "enc := json.NewEncoder(w)\nenc.SetOptions(json.UnknownFields(true))"
       }
     ],
     "archive/tar": [
       {
         "function": "Writer.AddFS",
         "description": "Now preserves symbolic links for filesystems implementing io/fs.ReadLinkFS.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "_ = tw.AddFS(os.DirFS(\"assets\"))"
       }
     ],
     "encoding/asn1": [
       {
         "function": "Unmarshal",
         "description": "Parses T61String and BMPString encodings consistently, rejecting malformed inputs previously accepted.",
-        "impact": "breaking"
+        "impact": "breaking",
+        "example": "_, err := asn1.Unmarshal(data, &dst) // malformed T61String now errors"
       }
     ],
     "crypto": [
       {
         "type": "MessageSigner",
         "description": "New interface for signers that hash messages internally, alongside helper `SignMessage` to prefer it when available.",
-        "impact": "new"
+        "impact": "new",
+        "example": "sig, err := crypto.SignMessage(signer, message, rand.Reader)"
       },
       {
         "description": "Changing the `fips140` GODEBUG flag after startup is now ignored instead of panicking, as documented.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "os.Setenv(\"GODEBUG\", \"fips140=on\") // toggling later has no effect"
       },
       {
         "description": "SHA-1, SHA-256, and SHA-512 slow down on amd64 systems lacking AVX2 instructions.",
-        "impact": "performance"
+        "impact": "performance",
+        "example": "// Benchmark hashing on pre-AVX2 amd64 hardware to gauge slowdown"
       }
     ],
     "crypto/ecdsa": [
       {
         "function": "ParseRawPrivateKey",
         "description": "Parses raw ECDSA private key bytes without relying on crypto/elliptic helpers.",
-        "impact": "new"
+        "impact": "new",
+        "example": "key, err := ecdsa.ParseRawPrivateKey(rawKey)"
       },
       {
         "function": "ParseUncompressedPublicKey",
         "description": "Decodes uncompressed ECDSA public keys into usable structures.",
-        "impact": "new"
+        "impact": "new",
+        "example": "pub, err := ecdsa.ParseUncompressedPublicKey(rawPub)"
       },
       {
         "method": "(*PrivateKey).Bytes",
         "description": "Serializes private keys using low-level encodings.",
-        "impact": "new"
+        "impact": "new",
+        "example": "data := priv.Bytes()"
       },
       {
         "method": "(*PublicKey).Bytes",
         "description": "Serializes public keys without extra elliptic or big.Int helpers.",
-        "impact": "new"
+        "impact": "new",
+        "example": "data := pub.Bytes()"
       },
       {
         "description": "FIPS 140-3 mode signing throughput is now on par with non-FIPS operation (4× faster).",
-        "impact": "performance"
+        "impact": "performance",
+        "example": "// Expect faster ECDSA signing in FIPS 140-3 mode"
       }
     ],
     "crypto/ed25519": [
       {
         "description": "FIPS 140-3 signing achieves the same performance as standard mode, yielding roughly 4× speedups.",
-        "impact": "performance"
+        "impact": "performance",
+        "example": "// Ed25519 FIPS mode now matches non-FIPS throughput"
       }
     ],
     "crypto/elliptic": [
       {
         "description": "Undocumented `Inverse` and `CombinedMult` methods have been removed from curve implementations.",
-        "impact": "breaking"
+        "impact": "breaking",
+        "example": "// Replace curve.Inverse usage with math/big or modular inverse helpers"
       }
     ],
     "crypto/rsa": [
       {
         "description": "Documentation clarifies that RSA public modulus values are public, matching existing Verify warnings.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "fmt.Println(cert.PublicKey.(*rsa.PublicKey).N) // explicitly public"
       },
       {
         "description": "RSA key generation completes roughly three times faster.",
-        "impact": "performance"
+        "impact": "performance",
+        "example": "priv, _ := rsa.GenerateKey(rand.Reader, 3072) // noticeably faster"
       }
     ],
     "crypto/sha1": [
       {
         "description": "SHA-1 hashing doubles in speed on amd64 when SHA-NI instructions are present.",
-        "impact": "performance"
+        "impact": "performance",
+        "example": "h := sha1.New(); h.Write(data) // faster on SHA-NI systems"
       }
     ],
     "crypto/sha3": [
       {
         "method": "(*SHA3).Clone",
         "description": "Implements hash.Cloner for duplicating hashing state.",
-        "impact": "new"
+        "impact": "new",
+        "example": "clone := h.Clone().(hash.Hash)"
       },
       {
         "description": "Hashing throughput doubles on Apple M-series processors.",
-        "impact": "performance"
+        "impact": "performance",
+        "example": "// Measure SHA3 performance improvements on Apple Silicon"
       }
     ],
     "crypto/tls": [
       {
         "field": "ConnectionState.CurveID",
         "description": "Exposes the key exchange group negotiated for the connection.",
-        "impact": "new"
+        "impact": "new",
+        "example": "state := conn.ConnectionState()\nfmt.Println(state.CurveID)"
       },
       {
         "function": "Config.GetEncryptedClientHelloKeys",
         "description": "Allows servers to supply Encrypted Client Hello keys dynamically.",
-        "impact": "new"
+        "impact": "new",
+        "example": "tlsConfig.GetEncryptedClientHelloKeys = func(info *tls.ClientHelloInfo) ([]tls.EncryptedClientHelloKey, error) { ... }"
       },
       {
         "description": "SHA-1 signatures are rejected during TLS 1.2 handshakes unless `GODEBUG=tlssha1=1` re-enables them.",
-        "impact": "breaking"
+        "impact": "breaking",
+        "example": "os.Setenv(\"GODEBUG\", \"tlssha1=1\") // legacy interop opt-in"
       },
       {
         "description": "In FIPS 140-3 mode, Extended Master Secret becomes mandatory and Ed25519/X25519MLKEM768 are now permitted.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "cfg := &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true} // EMS enforced in FIPS"
       },
       {
         "description": "Servers now prefer the highest mutually supported protocol version and both endpoints enforce stricter spec compliance.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "// Expect TLS servers to negotiate TLS 1.3 even if client lists TLS 1.2 first"
       }
     ],
     "crypto/x509": [
       {
         "function": "CreateCertificate",
         "description": "Certificate creation functions accept crypto.MessageSigner implementations for one-shot signing.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "_, err := x509.CreateCertificate(rand.Reader, tmpl, parent, pub, messageSigner)"
       },
       {
         "description": "SubjectKeyId defaults to truncated SHA-256 when missing, overridable via GODEBUG `x509sha256skid=0`.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "os.Setenv(\"GODEBUG\", \"x509sha256skid=0\") // revert to SHA-1"
       },
       {
         "description": "ParseCertificate rejects BasicConstraints with negative pathLenConstraint values.",
-        "impact": "breaking"
+        "impact": "breaking",
+        "example": "_, err := x509.ParseCertificate(badDER) // negative pathLen now errors"
       },
       {
         "description": "ParseCertificate handles T61String and BMPString encodings consistently, potentially rejecting malformed data.",
-        "impact": "breaking"
+        "impact": "breaking",
+        "example": "_, err := x509.ParseCertificate(certDER) // malformed strings rejected"
       }
     ],
     "debug/elf": [
       {
         "description": "Adds PT_RISCV_ATTRIBUTES and SHT_RISCV_ATTRIBUTES constants for RISC-V binaries.",
-        "impact": "new"
+        "impact": "new",
+        "example": "fmt.Println(elf.PT_RISCV_ATTRIBUTES)"
       }
     ],
     "go/ast": [
       {
         "description": "FilterPackage, PackageExports, MergePackageFiles, MergeMode, and related constants are deprecated alongside legacy Object/Package usage.",
-        "impact": "deprecation"
+        "impact": "deprecation",
+        "example": "// Replace go/ast.FilterPackage usage with go/packages"
       },
       {
         "function": "PreorderStack",
         "description": "Traverses syntax trees like Inspect while providing the stack of enclosing nodes for convenience.",
-        "impact": "new"
+        "impact": "new",
+        "example": "ast.PreorderStack(file, func(n ast.Node, stack []ast.Node) bool { return true })"
       }
     ],
     "go/parser": [
       {
         "function": "ParseDir",
         "description": "Deprecated in Go 1.25, reflecting the move away from legacy package inspection APIs.",
-        "impact": "deprecation"
+        "impact": "deprecation",
+        "example": "// Prefer packages.Load instead of go/parser.ParseDir"
       }
     ],
     "go/token": [
       {
         "method": "FileSet.AddExistingFiles",
         "description": "Allows construction of FileSets from pre-existing Files, easing long-lived tooling scenarios.",
-        "impact": "new"
+        "impact": "new",
+        "example": "fset.AddExistingFiles(existingFiles...)"
       }
     ],
     "go/types": [
       {
         "method": "(*Var).Kind",
         "description": "Classifies variables as package-level, receiver, parameter, result, local, or struct field.",
-        "impact": "new"
+        "impact": "new",
+        "example": "kind := v.Kind() // e.g., types.VarParam"
       },
       {
         "function": "LookupSelection",
         "description": "Looks up a field or method and returns it as a Selection, complementing LookupFieldOrMethod.",
-        "impact": "new"
+        "impact": "new",
+        "example": "sel, _ := types.LookupSelection(pkg, recv, true, \"Method\")"
       }
     ],
     "hash": [
       {
         "interface": "XOF",
         "description": "Defines extendable-output hash functionality for algorithms such as SHAKE.",
-        "impact": "new"
+        "impact": "new",
+        "example": "var x hash.XOF = sha3.NewShake256()"
       },
       {
         "description": "All standard Hash implementations now satisfy hash.Cloner to duplicate state.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "clone := h.(hash.Cloner).Clone()"
       }
     ],
     "hash/maphash": [
       {
         "method": "(*Hash).Clone",
         "description": "Implements hash.Cloner for copying random state.",
-        "impact": "new"
+        "impact": "new",
+        "example": "h2 := h.Clone().(*maphash.Hash)"
       }
     ],
     "io/fs": [
       {
         "interface": "ReadLinkFS",
         "description": "Adds opt-in symlink reading support for virtual filesystems.",
-        "impact": "new"
+        "impact": "new",
+        "example": "target, err := fs.Readlink(name)"
       }
     ],
     "log/slog": [
       {
         "function": "GroupAttrs",
         "description": "Convenience helper to build a group Attr from a slice of Attrs.",
-        "impact": "new"
+        "impact": "new",
+        "example": "logger.Info(\"req\", slog.GroupAttrs(\"headers\", attrs...))"
       },
       {
         "method": "Record.Source",
         "description": "Returns the source location associated with a log record when available.",
-        "impact": "new"
+        "impact": "new",
+        "example": "rec := slog.NewRecord(time.Now(), slog.LevelInfo, \"msg\", 0)\nrec.Source()"
       }
     ],
     "mime/multipart": [
       {
         "function": "FileContentDisposition",
         "description": "Constructs Content-Disposition headers for multipart file parts.",
-        "impact": "new"
+        "impact": "new",
+        "example": "header := multipart.FileContentDisposition(\"upload\", filename)"
       }
     ],
     "net": [
       {
         "function": "LookupMX",
         "description": "Returns MX answers that resemble IP addresses instead of discarding them, matching real-world resolver behavior.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "mx, _ := net.LookupMX(\"example.com\") // IP-like names preserved"
       },
       {
         "function": "ListenMulticastUDP",
         "description": "Supports IPv6 multicast addresses on Windows.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "conn, _ := net.ListenMulticastUDP(\"udp6\", nil, group)"
       },
       {
         "description": "Windows now supports converting between os.File and network connections using FileConn/FilePacketConn/FileListener and related methods.",
-        "impact": "new"
+        "impact": "new",
+        "example": "f := conn.File(); dup, _ := net.FileConn(f)"
       }
     ],
     "net/http": [
       {
         "type": "CrossOriginProtection",
         "description": "Implements Fetch-metadata-based CSRF mitigation that rejects unsafe cross-origin browser requests with optional bypass rules.",
-        "impact": "new"
+        "impact": "new",
+        "example": "handler := http.CrossOriginProtection(http.HandlerFunc(fn))"
       }
     ],
     "os": [
       {
         "function": "NewFile",
         "description": "On Windows, accepts handles opened for asynchronous I/O and associates them with the runtime IOCP so deadlines and nonblocking semantics work.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "f := os.NewFile(handle, \"pipe\")\nf.SetDeadline(time.Now().Add(time.Second))"
       },
       {
         "description": "DirFS and Root.FS now satisfy io/fs.ReadLinkFS, and CopyFS preserves symlinks when the source implements it.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "_ = os.CopyFS(dst, os.DirFS(\"src\")) // symlinks retained"
       },
       {
         "type": "Root",
         "description": "Gains filesystem management helpers including Chmod, Chown, Chtimes, Lchown, Link, MkdirAll, ReadFile, Readlink, RemoveAll, Rename, Symlink, and WriteFile.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "_ = root.MkdirAll(\"tmp/data\", 0o755)"
       }
     ],
     "reflect": [
       {
         "function": "TypeAssert",
         "description": "Converts a reflect.Value directly to a typed Go value without intermediate interface allocations.",
-        "impact": "new"
+        "impact": "new",
+        "example": "value := reflect.TypeAssert[int](rv)"
       }
     ],
     "regexp/syntax": [
       {
         "description": "Unicode class escapes now recognize Any, ASCII, Assigned, Cn, LC, and category aliases with case-insensitive, punctuation-agnostic matching per TR18.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "re := regexp.MustCompile(`\\p{Letter}`) // alias lookup works"
       }
     ],
     "runtime": [
       {
         "function": "AddCleanup",
         "description": "Cleanup callbacks execute concurrently and in parallel, improving throughput for heavy cleanup workloads.",
-        "impact": "performance"
+        "impact": "performance",
+        "example": "runtime.AddCleanup(obj, func() { go slowCleanup() })"
       },
       {
         "description": "With `GODEBUG=checkfinalizers=1`, the runtime inspects finalizer/cleanup usage each GC and reports queue lengths.",
-        "impact": "new"
+        "impact": "new",
+        "example": "os.Setenv(\"GODEBUG\", \"checkfinalizers=1\")"
       },
       {
         "function": "SetDefaultGOMAXPROCS",
         "description": "Resets GOMAXPROCS to the runtime default, re-enabling container-aware behavior after manual overrides.",
-        "impact": "new"
+        "impact": "new",
+        "example": "runtime.SetDefaultGOMAXPROCS()"
       }
     ],
     "runtime/pprof": [
       {
         "description": "Mutex profiles now attribute contention on runtime locks to the end of the blocking critical section; the runtimecontentionstacks GODEBUG toggle is removed.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "pprof.Lookup(\"mutex\").WriteTo(w, 0) // clearer runtime lock attribution"
       }
     ],
     "runtime/trace": [
       {
         "type": "FlightRecorder",
         "description": "Captures rolling execution traces that can be snapshotted on demand using configurable retention windows.",
-        "impact": "new"
+        "impact": "new",
+        "example": "rec := trace.NewFlightRecorder(cfg)\nrec.WriteTo(w)"
       }
     ],
     "sync": [
       {
         "method": "(*WaitGroup).Go",
         "description": "Launches a goroutine and increments the WaitGroup counter in one step for common patterns.",
-        "impact": "new"
+        "impact": "new",
+        "example": "wg.Go(func() error { defer cleanup(); return nil })"
       }
     ],
     "testing": [
       {
         "method": "(T|B|F).Attr",
         "description": "Emits structured key/value attributes into test output.",
-        "impact": "new"
+        "impact": "new",
+        "example": "t.Attr(\"component\", \"worker\")"
       },
       {
         "method": "(T|B|F).Output",
         "description": "Provides an io.Writer backed by the test log without file and line prefixes.",
-        "impact": "new"
+        "impact": "new",
+        "example": "fmt.Fprintln(t.Output(), \"streamed log line\")"
       },
       {
         "function": "AllocsPerRun",
         "description": "Now panics if invoked while tests run in parallel, preventing flaky measurements.",
-        "impact": "breaking"
+        "impact": "breaking",
+        "example": "testing.AllocsPerRun(1, func() { /* ensure no parallel tests */ })"
       }
     ],
     "testing/fstest": [
       {
         "type": "MapFS",
         "description": "Implements io/fs.ReadLinkFS for symlink-aware filesystem tests.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "target, _ := fstest.MapFS{\"link\": {Mode: fs.ModeSymlink, Target: \"dst\"}}.Readlink(\"link\")"
       },
       {
         "function": "TestFS",
         "description": "Validates ReadLinkFS behavior and avoids following symlinks to prevent unbounded recursion.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "fstest.TestFS(fs, \"dir\", \"dir/file\")"
       }
     ],
     "unicode": [
       {
         "var": "CategoryAliases",
         "description": "Exposes Unicode category alias names such as Letter for L.",
-        "impact": "new"
+        "impact": "new",
+        "example": "fmt.Println(unicode.CategoryAliases[\"Letter\"])"
       },
       {
         "description": "Adds Cn and LC category tables and folds C to include Cn, covering unassigned code points.",
-        "impact": "enhancement"
+        "impact": "enhancement",
+        "example": "_, ok := unicode.Cn[r] // detect unassigned code points"
       }
     ],
     "unique": [
       {
         "description": "Interned values are reclaimed sooner, more efficiently, and in parallel, avoiding memory blow-ups for highly unique data sets.",
-        "impact": "performance"
+        "impact": "performance",
+        "example": "u := unique.Make[string]()\n_ = u.Intern(\"value\")"
       },
       {
         "description": "Values containing Handle chains are collected in a single GC cycle once unused instead of requiring multiple collections.",
-        "impact": "performance"
+        "impact": "performance",
+        "example": "// Handle chains release promptly after Go 1.25"
       }
     ]
   }

--- a/data/releases/go1.25.json
+++ b/data/releases/go1.25.json
@@ -1,0 +1,520 @@
+{
+  "version": "1.25",
+  "release_date": "2025-08-01T00:00:00Z",
+  "summary": "Go 1.25 refines the toolchain with new go command options, adds container-aware runtime defaults and experimental GC and JSON stacks, and delivers broad standard library and platform improvements.",
+  "changes": [
+    {
+      "category": "language",
+      "description": "Language specification removes the notion of core types in favor of dedicated prose without changing program semantics.",
+      "impact": "enhancement"
+    },
+    {
+      "category": "toolchain",
+      "description": "`go build -asan` now enables C leak detection at program exit by default, reporting errors for unreleased C allocations unless disabled via ASAN_OPTIONS.",
+      "impact": "breaking"
+    },
+    {
+      "category": "toolchain",
+      "description": "Go distributions ship fewer prebuilt tool binaries, building rarely used tools on demand via `go tool`.",
+      "impact": "breaking"
+    },
+    {
+      "category": "toolchain",
+      "description": "New `go.mod` `ignore` directive lets module authors exclude directories from pattern matching while keeping them in module zip files.",
+      "impact": "new"
+    },
+    {
+      "category": "toolchain",
+      "description": "`go doc -http` starts a local documentation server and opens the requested documentation in a browser.",
+      "impact": "new"
+    },
+    {
+      "category": "toolchain",
+      "description": "`go version -m -json` emits the JSON encoding of embedded `runtime/debug.BuildInfo` data for binaries.",
+      "impact": "new"
+    },
+    {
+      "category": "toolchain",
+      "description": "Module path resolution now understands repository subdirectories via extended go-import meta tags with explicit subdir paths.",
+      "impact": "enhancement"
+    },
+    {
+      "category": "toolchain",
+      "description": "The new `work` package pattern matches every package in the active work module or workspace modules.",
+      "impact": "new"
+    },
+    {
+      "category": "toolchain",
+      "description": "When updating the `go` directive, the go command no longer injects a toolchain line reflecting its own version.",
+      "impact": "enhancement"
+    },
+    {
+      "category": "toolchain",
+      "description": "`go vet` gains `waitgroup` and `hostport` analyzers to flag misplaced WaitGroup.Add calls and unsafe fmt-based host:port formatting.",
+      "impact": "new"
+    },
+    {
+      "category": "runtime",
+      "description": "Default GOMAXPROCS becomes container-aware, capping to cgroup CPU bandwidth limits and updating as CPU availability changes unless overridden or disabled by GODEBUG.",
+      "impact": "performance"
+    },
+    {
+      "category": "runtime",
+      "description": "Experimental `greenteagc` garbage collector promises 10–40% lower GC overhead for small-object heavy workloads when enabled via GOEXPERIMENT.",
+      "impact": "new"
+    },
+    {
+      "category": "runtime",
+      "description": "Unhandled panic reports for recovered-and-repanicked values are condensed to a single message indicating the repanic.",
+      "impact": "enhancement"
+    },
+    {
+      "category": "runtime",
+      "description": "Linux runtimes name anonymous VMAs (for example `[anon: Go: heap]`) when the kernel supports CONFIG_ANON_VMA_NAME, controllable via GODEBUG `decoratemappings`.",
+      "impact": "enhancement"
+    },
+    {
+      "category": "compiler",
+      "description": "Compiler and linker now emit DWARF v5 debug info by default, reducing binary debug size and link time with GOEXPERIMENT=nodwarf5 as a temporary opt-out.",
+      "impact": "performance"
+    },
+    {
+      "category": "compiler",
+      "description": "Nil pointer checks occur promptly, so code that uses results before checking errors—such as ignoring a nil `*os.File`—now panics as required by the spec.",
+      "impact": "breaking"
+    },
+    {
+      "category": "compiler",
+      "description": "Slice backing arrays are stack-allocated in more situations, improving performance but exposing latent unsafe.Pointer misuse; tooling and flags exist to bisect or disable the change.",
+      "impact": "performance"
+    },
+    {
+      "category": "linker",
+      "description": "New `-funcalign=N` linker flag lets builds choose a custom function entry alignment per platform defaults.",
+      "impact": "new"
+    },
+    {
+      "category": "standard library",
+      "description": "New `testing/synctest` package introduces controlled bubbles and fake clocks for deterministic concurrency testing.",
+      "impact": "new"
+    },
+    {
+      "category": "standard library",
+      "description": "Experimental `encoding/json/v2` and `encoding/json/jsontext` packages ship behind GOEXPERIMENT=jsonv2, offering faster JSON decoding and richer configuration while leaving encoding/json behavior stable.",
+      "impact": "new"
+    },
+    {
+      "category": "ports",
+      "description": "macOS support now requires Monterey (12) or newer, ending support for earlier releases.",
+      "impact": "breaking"
+    },
+    {
+      "category": "ports",
+      "description": "Go 1.25 is the final release shipping the broken 32-bit windows/arm port ahead of its removal in Go 1.26.",
+      "impact": "deprecation"
+    },
+    {
+      "category": "ports",
+      "description": "linux/loong64 adds race detector support, C traceback collection, and internal-link-mode cgo builds.",
+      "impact": "enhancement"
+    },
+    {
+      "category": "ports",
+      "description": "linux/riscv64 now supports plugin mode and recognizes the `GORISCV64=rva23u64` application profile.",
+      "impact": "enhancement"
+    }
+  ],
+  "packages": {
+    "testing/synctest": [
+      {
+        "description": "Provides bubbles that sandbox concurrent tests with fake clocks and coordinated goroutine blocking.",
+        "impact": "new",
+        "example": "synctest.Test(func(t *synctest.T) { /* deterministic concurrent assertions */ })"
+      },
+      {
+        "function": "Wait",
+        "description": "Blocks until all goroutines in the bubble are waiting, ensuring the test reaches quiescence before assertions.",
+        "impact": "new"
+      }
+    ],
+    "encoding/json/v2": [
+      {
+        "description": "Experimental JSON implementation activated with GOEXPERIMENT=jsonv2, delivering faster decoding and new configuration options.",
+        "impact": "new"
+      },
+      {
+        "package": "encoding/json/jsontext",
+        "description": "Companion low-level package exposes JSON tokenization APIs when the experiment is enabled.",
+        "impact": "new"
+      }
+    ],
+    "encoding/json": [
+      {
+        "description": "Uses the v2 implementation when GOEXPERIMENT=jsonv2 is set, maintaining marshal semantics but changing error text and adding new options.",
+        "impact": "enhancement"
+      }
+    ],
+    "archive/tar": [
+      {
+        "function": "Writer.AddFS",
+        "description": "Now preserves symbolic links for filesystems implementing io/fs.ReadLinkFS.",
+        "impact": "enhancement"
+      }
+    ],
+    "encoding/asn1": [
+      {
+        "function": "Unmarshal",
+        "description": "Parses T61String and BMPString encodings consistently, rejecting malformed inputs previously accepted.",
+        "impact": "breaking"
+      }
+    ],
+    "crypto": [
+      {
+        "type": "MessageSigner",
+        "description": "New interface for signers that hash messages internally, alongside helper `SignMessage` to prefer it when available.",
+        "impact": "new"
+      },
+      {
+        "description": "Changing the `fips140` GODEBUG flag after startup is now ignored instead of panicking, as documented.",
+        "impact": "enhancement"
+      },
+      {
+        "description": "SHA-1, SHA-256, and SHA-512 slow down on amd64 systems lacking AVX2 instructions.",
+        "impact": "performance"
+      }
+    ],
+    "crypto/ecdsa": [
+      {
+        "function": "ParseRawPrivateKey",
+        "description": "Parses raw ECDSA private key bytes without relying on crypto/elliptic helpers.",
+        "impact": "new"
+      },
+      {
+        "function": "ParseUncompressedPublicKey",
+        "description": "Decodes uncompressed ECDSA public keys into usable structures.",
+        "impact": "new"
+      },
+      {
+        "method": "(*PrivateKey).Bytes",
+        "description": "Serializes private keys using low-level encodings.",
+        "impact": "new"
+      },
+      {
+        "method": "(*PublicKey).Bytes",
+        "description": "Serializes public keys without extra elliptic or big.Int helpers.",
+        "impact": "new"
+      },
+      {
+        "description": "FIPS 140-3 mode signing throughput is now on par with non-FIPS operation (4× faster).",
+        "impact": "performance"
+      }
+    ],
+    "crypto/ed25519": [
+      {
+        "description": "FIPS 140-3 signing achieves the same performance as standard mode, yielding roughly 4× speedups.",
+        "impact": "performance"
+      }
+    ],
+    "crypto/elliptic": [
+      {
+        "description": "Undocumented `Inverse` and `CombinedMult` methods have been removed from curve implementations.",
+        "impact": "breaking"
+      }
+    ],
+    "crypto/rsa": [
+      {
+        "description": "Documentation clarifies that RSA public modulus values are public, matching existing Verify warnings.",
+        "impact": "enhancement"
+      },
+      {
+        "description": "RSA key generation completes roughly three times faster.",
+        "impact": "performance"
+      }
+    ],
+    "crypto/sha1": [
+      {
+        "description": "SHA-1 hashing doubles in speed on amd64 when SHA-NI instructions are present.",
+        "impact": "performance"
+      }
+    ],
+    "crypto/sha3": [
+      {
+        "method": "(*SHA3).Clone",
+        "description": "Implements hash.Cloner for duplicating hashing state.",
+        "impact": "new"
+      },
+      {
+        "description": "Hashing throughput doubles on Apple M-series processors.",
+        "impact": "performance"
+      }
+    ],
+    "crypto/tls": [
+      {
+        "field": "ConnectionState.CurveID",
+        "description": "Exposes the key exchange group negotiated for the connection.",
+        "impact": "new"
+      },
+      {
+        "function": "Config.GetEncryptedClientHelloKeys",
+        "description": "Allows servers to supply Encrypted Client Hello keys dynamically.",
+        "impact": "new"
+      },
+      {
+        "description": "SHA-1 signatures are rejected during TLS 1.2 handshakes unless `GODEBUG=tlssha1=1` re-enables them.",
+        "impact": "breaking"
+      },
+      {
+        "description": "In FIPS 140-3 mode, Extended Master Secret becomes mandatory and Ed25519/X25519MLKEM768 are now permitted.",
+        "impact": "enhancement"
+      },
+      {
+        "description": "Servers now prefer the highest mutually supported protocol version and both endpoints enforce stricter spec compliance.",
+        "impact": "enhancement"
+      }
+    ],
+    "crypto/x509": [
+      {
+        "function": "CreateCertificate",
+        "description": "Certificate creation functions accept crypto.MessageSigner implementations for one-shot signing.",
+        "impact": "enhancement"
+      },
+      {
+        "description": "SubjectKeyId defaults to truncated SHA-256 when missing, overridable via GODEBUG `x509sha256skid=0`.",
+        "impact": "enhancement"
+      },
+      {
+        "description": "ParseCertificate rejects BasicConstraints with negative pathLenConstraint values.",
+        "impact": "breaking"
+      },
+      {
+        "description": "ParseCertificate handles T61String and BMPString encodings consistently, potentially rejecting malformed data.",
+        "impact": "breaking"
+      }
+    ],
+    "debug/elf": [
+      {
+        "description": "Adds PT_RISCV_ATTRIBUTES and SHT_RISCV_ATTRIBUTES constants for RISC-V binaries.",
+        "impact": "new"
+      }
+    ],
+    "go/ast": [
+      {
+        "description": "FilterPackage, PackageExports, MergePackageFiles, MergeMode, and related constants are deprecated alongside legacy Object/Package usage.",
+        "impact": "deprecation"
+      },
+      {
+        "function": "PreorderStack",
+        "description": "Traverses syntax trees like Inspect while providing the stack of enclosing nodes for convenience.",
+        "impact": "new"
+      }
+    ],
+    "go/parser": [
+      {
+        "function": "ParseDir",
+        "description": "Deprecated in Go 1.25, reflecting the move away from legacy package inspection APIs.",
+        "impact": "deprecation"
+      }
+    ],
+    "go/token": [
+      {
+        "method": "FileSet.AddExistingFiles",
+        "description": "Allows construction of FileSets from pre-existing Files, easing long-lived tooling scenarios.",
+        "impact": "new"
+      }
+    ],
+    "go/types": [
+      {
+        "method": "(*Var).Kind",
+        "description": "Classifies variables as package-level, receiver, parameter, result, local, or struct field.",
+        "impact": "new"
+      },
+      {
+        "function": "LookupSelection",
+        "description": "Looks up a field or method and returns it as a Selection, complementing LookupFieldOrMethod.",
+        "impact": "new"
+      }
+    ],
+    "hash": [
+      {
+        "interface": "XOF",
+        "description": "Defines extendable-output hash functionality for algorithms such as SHAKE.",
+        "impact": "new"
+      },
+      {
+        "description": "All standard Hash implementations now satisfy hash.Cloner to duplicate state.",
+        "impact": "enhancement"
+      }
+    ],
+    "hash/maphash": [
+      {
+        "method": "(*Hash).Clone",
+        "description": "Implements hash.Cloner for copying random state.",
+        "impact": "new"
+      }
+    ],
+    "io/fs": [
+      {
+        "interface": "ReadLinkFS",
+        "description": "Adds opt-in symlink reading support for virtual filesystems.",
+        "impact": "new"
+      }
+    ],
+    "log/slog": [
+      {
+        "function": "GroupAttrs",
+        "description": "Convenience helper to build a group Attr from a slice of Attrs.",
+        "impact": "new"
+      },
+      {
+        "method": "Record.Source",
+        "description": "Returns the source location associated with a log record when available.",
+        "impact": "new"
+      }
+    ],
+    "mime/multipart": [
+      {
+        "function": "FileContentDisposition",
+        "description": "Constructs Content-Disposition headers for multipart file parts.",
+        "impact": "new"
+      }
+    ],
+    "net": [
+      {
+        "function": "LookupMX",
+        "description": "Returns MX answers that resemble IP addresses instead of discarding them, matching real-world resolver behavior.",
+        "impact": "enhancement"
+      },
+      {
+        "function": "ListenMulticastUDP",
+        "description": "Supports IPv6 multicast addresses on Windows.",
+        "impact": "enhancement"
+      },
+      {
+        "description": "Windows now supports converting between os.File and network connections using FileConn/FilePacketConn/FileListener and related methods.",
+        "impact": "new"
+      }
+    ],
+    "net/http": [
+      {
+        "type": "CrossOriginProtection",
+        "description": "Implements Fetch-metadata-based CSRF mitigation that rejects unsafe cross-origin browser requests with optional bypass rules.",
+        "impact": "new"
+      }
+    ],
+    "os": [
+      {
+        "function": "NewFile",
+        "description": "On Windows, accepts handles opened for asynchronous I/O and associates them with the runtime IOCP so deadlines and nonblocking semantics work.",
+        "impact": "enhancement"
+      },
+      {
+        "description": "DirFS and Root.FS now satisfy io/fs.ReadLinkFS, and CopyFS preserves symlinks when the source implements it.",
+        "impact": "enhancement"
+      },
+      {
+        "type": "Root",
+        "description": "Gains filesystem management helpers including Chmod, Chown, Chtimes, Lchown, Link, MkdirAll, ReadFile, Readlink, RemoveAll, Rename, Symlink, and WriteFile.",
+        "impact": "enhancement"
+      }
+    ],
+    "reflect": [
+      {
+        "function": "TypeAssert",
+        "description": "Converts a reflect.Value directly to a typed Go value without intermediate interface allocations.",
+        "impact": "new"
+      }
+    ],
+    "regexp/syntax": [
+      {
+        "description": "Unicode class escapes now recognize Any, ASCII, Assigned, Cn, LC, and category aliases with case-insensitive, punctuation-agnostic matching per TR18.",
+        "impact": "enhancement"
+      }
+    ],
+    "runtime": [
+      {
+        "function": "AddCleanup",
+        "description": "Cleanup callbacks execute concurrently and in parallel, improving throughput for heavy cleanup workloads.",
+        "impact": "performance"
+      },
+      {
+        "description": "With `GODEBUG=checkfinalizers=1`, the runtime inspects finalizer/cleanup usage each GC and reports queue lengths.",
+        "impact": "new"
+      },
+      {
+        "function": "SetDefaultGOMAXPROCS",
+        "description": "Resets GOMAXPROCS to the runtime default, re-enabling container-aware behavior after manual overrides.",
+        "impact": "new"
+      }
+    ],
+    "runtime/pprof": [
+      {
+        "description": "Mutex profiles now attribute contention on runtime locks to the end of the blocking critical section; the runtimecontentionstacks GODEBUG toggle is removed.",
+        "impact": "enhancement"
+      }
+    ],
+    "runtime/trace": [
+      {
+        "type": "FlightRecorder",
+        "description": "Captures rolling execution traces that can be snapshotted on demand using configurable retention windows.",
+        "impact": "new"
+      }
+    ],
+    "sync": [
+      {
+        "method": "(*WaitGroup).Go",
+        "description": "Launches a goroutine and increments the WaitGroup counter in one step for common patterns.",
+        "impact": "new"
+      }
+    ],
+    "testing": [
+      {
+        "method": "(T|B|F).Attr",
+        "description": "Emits structured key/value attributes into test output.",
+        "impact": "new"
+      },
+      {
+        "method": "(T|B|F).Output",
+        "description": "Provides an io.Writer backed by the test log without file and line prefixes.",
+        "impact": "new"
+      },
+      {
+        "function": "AllocsPerRun",
+        "description": "Now panics if invoked while tests run in parallel, preventing flaky measurements.",
+        "impact": "breaking"
+      }
+    ],
+    "testing/fstest": [
+      {
+        "type": "MapFS",
+        "description": "Implements io/fs.ReadLinkFS for symlink-aware filesystem tests.",
+        "impact": "enhancement"
+      },
+      {
+        "function": "TestFS",
+        "description": "Validates ReadLinkFS behavior and avoids following symlinks to prevent unbounded recursion.",
+        "impact": "enhancement"
+      }
+    ],
+    "unicode": [
+      {
+        "var": "CategoryAliases",
+        "description": "Exposes Unicode category alias names such as Letter for L.",
+        "impact": "new"
+      },
+      {
+        "description": "Adds Cn and LC category tables and folds C to include Cn, covering unassigned code points.",
+        "impact": "enhancement"
+      }
+    ],
+    "unique": [
+      {
+        "description": "Interned values are reclaimed sooner, more efficiently, and in parallel, avoiding memory blow-ups for highly unique data sets.",
+        "impact": "performance"
+      },
+      {
+        "description": "Values containing Handle chains are collected in a single GC cycle once unused instead of requiring multiple collections.",
+        "impact": "performance"
+      }
+    ]
+  }
+}

--- a/main.go
+++ b/main.go
@@ -54,10 +54,10 @@ func NewMCPServer() (*server.MCPServer, error) {
 
 	// Define the go-updates tool
 	goUpdatesTool := mcp.NewTool("go-updates",
-		mcp.WithDescription("Get comprehensive Go language features and best practices for your project version in structured Markdown format. Supports Go 1.13-1.24, displaying all available features chronologically to help LLM coding agents use modern Go patterns and standard library functions efficiently."),
+		mcp.WithDescription("Get comprehensive Go language features and best practices for your project version in structured Markdown format. Supports Go 1.13-1.25, displaying all available features chronologically to help LLM coding agents use modern Go patterns and standard library functions efficiently."),
 		mcp.WithString("version",
 			mcp.Required(),
-			mcp.Description("Go version your project is currently using (supported: '1.13' through '1.24', e.g., '1.21', '1.22', '1.23', '1.24')")),
+			mcp.Description("Go version your project is currently using (supported: '1.13' through '1.25', e.g., '1.21', '1.22', '1.23', '1.25')")),
 		mcp.WithString("package",
 			mcp.Description("Optional: filter features for a specific standard library package (e.g., 'net/http', 'context', 'slices', 'maps')")))
 
@@ -77,7 +77,7 @@ func main() {
 	logger.Info("Initializing recent-go-mcp server",
 		"component", "recent-go-mcp",
 		"version", Version,
-		"supportedGoVersions", "1.13-1.24",
+		"supportedGoVersions", "1.13-1.25",
 		"architecture", "clean-architecture-with-DI")
 
 	// Create MCP server with dependencies and tools

--- a/make_changelog_prompt.md
+++ b/make_changelog_prompt.md
@@ -5,8 +5,8 @@ Create a comprehensive JSON changelog file for Go version releases that matches 
 
 ## Input Requirements
 You will be provided with:
-1. **Go version number** (e.g., "1.24")
-2. **Official Go release notes URL** (e.g., https://go.dev/doc/go1.24)
+1. **Go version number** (e.g., "1.25")
+2. **Official Go release notes URL** (e.g., https://go.dev/doc/go1.25)
 3. **Go language specification changes** (if applicable)
 4. **Standard library documentation** for new/changed packages
 


### PR DESCRIPTION
## Summary
- add the Go 1.25 release entry with language, toolchain, runtime, compiler, linker, library, and port updates
- document package-level additions and behavior changes including new experiments, APIs, and deprecations
- refresh documentation, guidance files, and tool descriptions to cover Go 1.13-1.25 support and updated examples

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f1c21e69dc833091eb4c2387b7963c